### PR TITLE
added value for handle and fixed TcpSocket lifetime bug

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -135,6 +135,7 @@ fn main() {
 
             if socket.may_recv() {
                 let data = socket.recv(|buffer| {
+                    let recvd_len = buffer.len();
                     let mut data = buffer.to_owned();
                     if data.len() > 0 {
                         debug!("tcp:6970 recv data: {:?}",
@@ -143,7 +144,7 @@ fn main() {
                         data.reverse();
                         data.extend(b"\n");
                     }
-                    (data.len(), data)
+                    (recvd_len, data)
                 }).unwrap();
                 if socket.can_send() && data.len() > 0 {
                     debug!("tcp:6970 send data: {:?}",

--- a/src/dhcp/mod.rs
+++ b/src/dhcp/mod.rs
@@ -2,4 +2,4 @@ pub const UDP_SERVER_PORT: u16 = 67;
 pub const UDP_CLIENT_PORT: u16 = 68;
 
 mod clientv4;
-pub use self::clientv4::Client as Dhcpv4Client;
+pub use self::clientv4::{Client as Dhcpv4Client, Config as Dhcpv4Config};

--- a/src/iface/neighbor.rs
+++ b/src/iface/neighbor.rs
@@ -6,9 +6,6 @@ use managed::ManagedMap;
 use wire::{EthernetAddress, IpAddress};
 use time::{Duration, Instant};
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use core::mem;
-
 /// A cached neighbor.
 ///
 /// A neighbor mapping translates from a protocol address to a hardware address,
@@ -104,7 +101,7 @@ impl<'a> Cache<'a> {
                         .filter(|(_, v)| timestamp < v.expires_at)
                         .collect();
 
-                    mem::replace(map, new_btree_map);
+                    *map = new_btree_map;
                 }
             }
         };

--- a/src/iface/route.rs
+++ b/src/iface/route.rs
@@ -117,7 +117,7 @@ impl<'a> Routes<'a> {
             _ => unimplemented!()
         };
 
-        for (prefix, route) in self.storage.range((Bound::Unbounded, Bound::Included(cidr))).rev() {
+        for (prefix, route) in self.storage.range((Bound::Unbounded::<IpCidr>, Bound::Included(cidr))).rev() {
             // TODO: do something with route.preferred_until
             if let Some(expires_at) = route.expires_at {
                 if timestamp > expires_at {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,17 +66,17 @@
 //! of a packet, it is still logged correctly and in full.
 //!
 //! ## Packet and representation layer support
-//!  | Protocol | Packet | Representation |
-//!  |----------|--------|----------------|
-//!  | Ethernet | Yes    | Yes            |
-//!  | ARP      | Yes    | Yes            |
-//!  | IPv4     | Yes    | Yes            |
-//!  | ICMPv4   | Yes    | Yes            |
-//!  | IGMPv1/2 | Yes    | Yes            |
-//!  | IPv6     | Yes    | Yes            |
-//!  | ICMPv6   | Yes    | Yes            |
-//!  | TCP      | Yes    | Yes            |
-//!  | UDP      | Yes    | Yes            |
+//! | Protocol | Packet | Representation |
+//! |----------|--------|----------------|
+//! | Ethernet | Yes    | Yes            |
+//! | ARP      | Yes    | Yes            |
+//! | IPv4     | Yes    | Yes            |
+//! | ICMPv4   | Yes    | Yes            |
+//! | IGMPv1/2 | Yes    | Yes            |
+//! | IPv6     | Yes    | Yes            |
+//! | ICMPv6   | Yes    | Yes            |
+//! | TCP      | Yes    | Yes            |
+//! | UDP      | Yes    | Yes            |
 //!
 //! [wire]: wire/index.html
 //! [osi]: https://en.wikipedia.org/wiki/OSI_model

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,11 @@ pub enum Error {
     /// or a TCP connection attempt was made to an unspecified endpoint.
     Unaddressable,
 
+    /// The operation is finished.
+    /// E.g. when reading from a TCP socket, there's no more data to read because the remote
+    /// has closed the connection.
+    Finished,
+
     /// An incoming packet could not be parsed because some of its fields were out of bounds
     /// of the received data.
     Truncated,
@@ -165,6 +170,7 @@ impl fmt::Display for Error {
             &Error::Exhausted     => write!(f, "buffer space exhausted"),
             &Error::Illegal       => write!(f, "illegal operation"),
             &Error::Unaddressable => write!(f, "unaddressable destination"),
+            &Error::Finished      => write!(f, "operation finished"),
             &Error::Truncated     => write!(f, "truncated packet"),
             &Error::Checksum      => write!(f, "checksum error"),
             &Error::Unrecognized  => write!(f, "unrecognized packet"),

--- a/src/socket/set.rs
+++ b/src/socket/set.rs
@@ -19,6 +19,12 @@ pub struct Item<'a, 'b: 'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
 pub struct Handle(usize);
 
+impl Handle {
+    pub fn value(self) -> usize {
+        self.0
+    }
+}
+
 impl fmt::Display for Handle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "#{}", self.0)

--- a/src/socket/set.rs
+++ b/src/socket/set.rs
@@ -19,12 +19,6 @@ pub struct Item<'a, 'b: 'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
 pub struct Handle(usize);
 
-impl Handle {
-    pub fn value(self) -> usize {
-        self.0
-    }
-}
-
 impl fmt::Display for Handle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "#{}", self.0)

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1658,8 +1658,8 @@ impl<'a> TcpSocket<'a> {
     }
 }
 
-impl<'a> Into<Socket<'a, 'a>> for TcpSocket<'a> {
-    fn into(self) -> Socket<'a, 'a> {
+impl<'a, 'b> Into<Socket<'a, 'b>> for TcpSocket<'a> {
+    fn into(self) -> Socket<'a, 'b> {
         Socket::Tcp(self)
     }
 }

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1376,7 +1376,6 @@ impl<'a> TcpSocket<'a> {
             // packets for every packet it receives.
             net_trace!("{}:{}:{}: ACKing incoming segment",
                        self.meta.handle, self.local_endpoint, self.remote_endpoint);
-            self.remote_last_ack = Some(self.remote_seq_no + self.rx_buffer.len());
             Ok(Some(self.ack_reply(ip_repr, &repr)))
         } else {
             Ok(None)

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -483,9 +483,9 @@ impl<'a> TcpSocket<'a> {
         // If local address is not provided, use an unspecified address but a specified protocol.
         // This lets us lower IpRepr later to determine IP header size and calculate MSS,
         // but without committing to a specific address right away.
-        let local_addr = match remote_endpoint.addr {
-            IpAddress::Unspecified => return Err(Error::Unaddressable),
-            _ => remote_endpoint.addr.to_unspecified(),
+        let local_addr = match local_endpoint.addr {
+            IpAddress::Unspecified => remote_endpoint.addr.to_unspecified(),
+            ip => ip,
         };
         let local_endpoint = IpEndpoint { addr: local_addr, ..local_endpoint };
 
@@ -1894,6 +1894,16 @@ mod test {
         s
     }
 
+    fn socket_syn_sent_with_local_ipendpoint(local: IpEndpoint) -> TcpSocket<'static> {
+        let mut s = socket();
+        s.state           = State::SynSent;
+        s.local_endpoint  = local;
+        s.remote_endpoint = REMOTE_END;
+        s.local_seq_no    = LOCAL_SEQ;
+        s.remote_last_seq = LOCAL_SEQ;
+        s
+    }
+
     fn socket_established_with_buffer_sizes(tx_len: usize, rx_len: usize) -> TcpSocket<'static> {
         let mut s = socket_syn_received_with_buffer_sizes(tx_len, rx_len);
         s.state           = State::Established;
@@ -2318,6 +2328,9 @@ mod test {
                    Err(Error::Unaddressable));
         assert_eq!(s.connect((IpAddress::Unspecified, 80), LOCAL_END),
                    Err(Error::Unaddressable));
+        s.connect(REMOTE_END, LOCAL_END).expect("Connect failed with valid parameters");
+        assert_eq!(s.local_endpoint(), LOCAL_END);
+        assert_eq!(s.remote_endpoint(), REMOTE_END);
     }
 
     #[test]
@@ -2378,7 +2391,7 @@ mod test {
         let mut s = socket();
         s.local_seq_no    = LOCAL_SEQ;
         s.connect(REMOTE_END, LOCAL_END).unwrap();
-        sanity!(s, socket_syn_sent());
+        sanity!(s, socket_syn_sent_with_local_ipendpoint(LOCAL_END));
     }
 
     #[test]

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -742,8 +742,13 @@ impl<'a> TcpSocket<'a> {
     /// Call `f` with the largest contiguous slice of octets in the receive buffer,
     /// and dequeue the amount of elements returned by `f`.
     ///
-    /// This function returns `Err(Error::Illegal)` if the receive half of
-    /// the connection is not open; see [may_recv](#method.may_recv).
+    /// This function errors if the receive half of the connection is not open.
+    ///
+    /// If the receive half has been gracefully closed (with a FIN packet), `Err(Error::Finished)`
+    /// is returned. In this case, the previously received data is guaranteed to be complete.
+    ///
+    /// In all other cases, `Err(Error::Illegal)` is returned and previously received data (if any)
+    /// may be incomplete (truncated).
     pub fn recv<'b, F, R>(&'b mut self, f: F) -> Result<R>
             where F: FnOnce(&'b mut [u8]) -> (usize, R) {
         self.recv_impl(|rx_buffer| {

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -192,6 +192,7 @@ pub struct TcpSocket<'a> {
     timer:           Timer,
     assembler:       Assembler,
     rx_buffer:       SocketBuffer<'a>,
+    rx_fin_received: bool,
     tx_buffer:       SocketBuffer<'a>,
     /// Interval after which, if no inbound packets are received, the connection is aborted.
     timeout:         Option<Duration>,
@@ -276,6 +277,7 @@ impl<'a> TcpSocket<'a> {
             assembler:       Assembler::new(rx_buffer.capacity()),
             tx_buffer:       tx_buffer,
             rx_buffer:       rx_buffer,
+            rx_fin_received: false,
             timeout:         None,
             keep_alive:      None,
             hop_limit:       None,
@@ -419,6 +421,7 @@ impl<'a> TcpSocket<'a> {
         self.assembler       = Assembler::new(self.rx_buffer.capacity());
         self.tx_buffer.clear();
         self.rx_buffer.clear();
+        self.rx_fin_received = false;
         self.keep_alive      = None;
         self.timeout         = None;
         self.hop_limit       = None;
@@ -706,12 +709,23 @@ impl<'a> TcpSocket<'a> {
         })
     }
 
-    fn recv_impl<'b, F, R>(&'b mut self, f: F) -> Result<R>
-            where F: FnOnce(&'b mut SocketBuffer<'a>) -> (usize, R) {
+    fn recv_error_check(&mut self) -> Result<()> {
         // We may have received some data inside the initial SYN, but until the connection
         // is fully open we must not dequeue any data, as it may be overwritten by e.g.
         // another (stale) SYN. (We do not support TCP Fast Open.)
-        if !self.may_recv() { return Err(Error::Illegal) }
+        if !self.may_recv() {
+            if self.rx_fin_received {
+                return Err(Error::Finished)
+            }
+            return Err(Error::Illegal)
+        }
+
+        Ok(())
+    }
+
+    fn recv_impl<'b, F, R>(&'b mut self, f: F) -> Result<R>
+            where F: FnOnce(&'b mut SocketBuffer<'a>) -> (usize, R) {
+        self.recv_error_check()?;
 
         let _old_length = self.rx_buffer.len();
         let (size, result) = f(&mut self.rx_buffer);
@@ -755,8 +769,7 @@ impl<'a> TcpSocket<'a> {
     ///
     /// This function otherwise behaves identically to [recv](#method.recv).
     pub fn peek(&mut self, size: usize) -> Result<&[u8]> {
-        // See recv() above.
-        if !self.may_recv() { return Err(Error::Illegal) }
+        self.recv_error_check()?;
 
         let buffer = self.rx_buffer.get_allocated(0, size);
         if buffer.len() > 0 {
@@ -1140,6 +1153,7 @@ impl<'a> TcpSocket<'a> {
             // 7th and 8th steps in the "SEGMENT ARRIVES" event describe this behavior.
             (State::SynReceived, TcpControl::Fin) => {
                 self.remote_seq_no  += 1;
+                self.rx_fin_received = true;
                 self.set_state(State::CloseWait);
                 self.timer.set_for_idle(timestamp, self.keep_alive);
             }
@@ -1170,6 +1184,7 @@ impl<'a> TcpSocket<'a> {
             // FIN packets in ESTABLISHED state indicate the remote side has closed.
             (State::Established, TcpControl::Fin) => {
                 self.remote_seq_no  += 1;
+                self.rx_fin_received = true;
                 self.set_state(State::CloseWait);
                 self.timer.set_for_idle(timestamp, self.keep_alive);
             }
@@ -1187,6 +1202,7 @@ impl<'a> TcpSocket<'a> {
             // if they also acknowledge our FIN.
             (State::FinWait1, TcpControl::Fin) => {
                 self.remote_seq_no  += 1;
+                self.rx_fin_received = true;
                 if ack_of_fin {
                     self.set_state(State::TimeWait);
                     self.timer.set_for_close(timestamp);
@@ -1204,6 +1220,7 @@ impl<'a> TcpSocket<'a> {
             // FIN packets in FIN-WAIT-2 state change it to TIME-WAIT.
             (State::FinWait2, TcpControl::Fin) => {
                 self.remote_seq_no  += 1;
+                self.rx_fin_received = true;
                 self.set_state(State::TimeWait);
                 self.timer.set_for_close(timestamp);
             }
@@ -4598,6 +4615,160 @@ mod test {
             payload:    &b"def"[..],
             ..RECV_TEMPL
         }));
+    }
+
+    // =========================================================================================//
+    // Tests for graceful vs ungraceful rx close
+    // =========================================================================================//
+
+    #[test]
+    fn test_rx_close_fin() {
+        let mut s = socket_established();
+        send!(s, TcpRepr {
+            control:    TcpControl::Fin,
+            seq_number: REMOTE_SEQ + 1,
+            ack_number: Some(LOCAL_SEQ + 1),
+            payload:    &b"abc"[..],
+            ..SEND_TEMPL
+        });
+        s.recv(|data| {
+            assert_eq!(data, b"abc");
+            (3, ())
+        }).unwrap();
+        assert_eq!(s.recv(|_| (0, ())), Err(Error::Finished));
+    }
+
+    #[test]
+    fn test_rx_close_fin_in_fin_wait_1() {
+        let mut s = socket_fin_wait_1();
+        send!(s, TcpRepr {
+            control:    TcpControl::Fin,
+            seq_number: REMOTE_SEQ + 1,
+            ack_number: Some(LOCAL_SEQ + 1),
+            payload:    &b"abc"[..],
+            ..SEND_TEMPL
+        });
+        assert_eq!(s.state, State::Closing);
+        s.recv(|data| {
+            assert_eq!(data, b"abc");
+            (3, ())
+        }).unwrap();
+        assert_eq!(s.recv(|_| (0, ())), Err(Error::Finished));
+    }
+
+    #[test]
+    fn test_rx_close_fin_in_fin_wait_2() {
+        let mut s = socket_fin_wait_2();
+        send!(s, TcpRepr {
+            control:    TcpControl::Fin,
+            seq_number: REMOTE_SEQ + 1,
+            ack_number: Some(LOCAL_SEQ + 1 + 1),
+            payload:    &b"abc"[..],
+            ..SEND_TEMPL
+        });
+        assert_eq!(s.state, State::TimeWait);
+        s.recv(|data| {
+            assert_eq!(data, b"abc");
+            (3, ())
+        }).unwrap();
+        assert_eq!(s.recv(|_| (0, ())), Err(Error::Finished));
+    }
+
+
+
+    #[test]
+    fn test_rx_close_fin_with_hole() {
+        let mut s = socket_established();
+        send!(s, TcpRepr {
+            seq_number: REMOTE_SEQ + 1,
+            ack_number: Some(LOCAL_SEQ + 1),
+            payload:    &b"abc"[..],
+            ..SEND_TEMPL
+        });
+        send!(s, TcpRepr {
+            control:    TcpControl::Fin,
+            seq_number: REMOTE_SEQ + 1 + 6,
+            ack_number: Some(LOCAL_SEQ + 1),
+            payload:    &b"ghi"[..],
+            ..SEND_TEMPL
+        }, Ok(Some(TcpRepr {
+            seq_number: LOCAL_SEQ + 1,
+            ack_number: Some(REMOTE_SEQ + 1 + 3),
+            window_len: 61,
+            ..RECV_TEMPL
+        })));
+        s.recv(|data| {
+            assert_eq!(data, b"abc");
+            (3, ())
+        }).unwrap();
+        s.recv(|data| {
+            assert_eq!(data, b"");
+            (0, ())
+        }).unwrap();
+        send!(s, TcpRepr {
+            control:    TcpControl::Rst,
+            seq_number: REMOTE_SEQ + 1 + 9,
+            ack_number: Some(LOCAL_SEQ + 1),
+            ..SEND_TEMPL
+        });
+        // Error must be `Illegal` even if we've received a FIN,
+        // because we are missing data.
+        assert_eq!(s.recv(|_| (0, ())), Err(Error::Illegal));
+    }
+
+    #[test]
+    fn test_rx_close_rst() {
+        let mut s = socket_established();
+        send!(s, TcpRepr {
+            seq_number: REMOTE_SEQ + 1,
+            ack_number: Some(LOCAL_SEQ + 1),
+            payload:    &b"abc"[..],
+            ..SEND_TEMPL
+        });
+        send!(s, TcpRepr {
+            control:    TcpControl::Rst,
+            seq_number: REMOTE_SEQ + 1 + 3,
+            ack_number: Some(LOCAL_SEQ + 1),
+            ..SEND_TEMPL
+        });
+        s.recv(|data| {
+            assert_eq!(data, b"abc");
+            (3, ())
+        }).unwrap();
+        assert_eq!(s.recv(|_| (0, ())), Err(Error::Illegal));
+    }
+
+    #[test]
+    fn test_rx_close_rst_with_hole() {
+        let mut s = socket_established();
+        send!(s, TcpRepr {
+            seq_number: REMOTE_SEQ + 1,
+            ack_number: Some(LOCAL_SEQ + 1),
+            payload:    &b"abc"[..],
+            ..SEND_TEMPL
+        });
+        send!(s, TcpRepr {
+            seq_number: REMOTE_SEQ + 1 + 6,
+            ack_number: Some(LOCAL_SEQ + 1),
+            payload:    &b"ghi"[..],
+            ..SEND_TEMPL
+        }, Ok(Some(TcpRepr {
+            seq_number: LOCAL_SEQ + 1,
+            ack_number: Some(REMOTE_SEQ + 1 + 3),
+            window_len: 61,
+            ..RECV_TEMPL
+        })));
+        send!(s, TcpRepr {
+            control:    TcpControl::Rst,
+            seq_number: REMOTE_SEQ + 1 + 9,
+            ack_number: Some(LOCAL_SEQ + 1),
+            ..SEND_TEMPL
+        });
+        s.recv(|data| {
+            assert_eq!(data, b"abc");
+            (3, ())
+        }).unwrap();
+        assert_eq!(s.recv(|_| (0, ())), Err(Error::Illegal));
     }
 
     // =========================================================================================//


### PR DESCRIPTION
Hi. I found no way of getting the value for Handle so I added one. Since it's defined in another library, doing `handle.0` wont work (it says the field is private).

Also, I fixed the problem with the TcpSocket

Tell me if it's okay.